### PR TITLE
[#59] Comment 생성/삭제 시 ReviewMetrics의 CommentCount 갱신

### DIFF
--- a/src/main/java/com/part3/deokhugam/domain/ReviewMetrics.java
+++ b/src/main/java/com/part3/deokhugam/domain/ReviewMetrics.java
@@ -23,6 +23,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class ReviewMetrics extends BaseEntity {
+
   @Id
   @Column(name = "review_id")
   private UUID reviewId;
@@ -38,6 +39,14 @@ public class ReviewMetrics extends BaseEntity {
 
   @Column(name = "comment_count", nullable = false)
   @Builder.Default
-  private int commentCount= 0;
+  private int commentCount = 0;
+
+  public void increaseCommentCount() {
+    this.commentCount++;
+  }
+
+  public void decreaseCommentCount() {
+    this.commentCount--;
+  }
 
 }


### PR DESCRIPTION
PR 타입(하나 이상의 PR 타입을 선택해주세요),
- [x]  기능 추가,,
- [ ]  기능 삭제,,
- [ ]  버그 수정,,
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트,,

반영 브랜치
feature/59-comment-count -> develop

이슈 번호
close #59

변경 사항

1.ReviewMetrics에 CommentCount 계산 메서드 추가
2. CommentService의 create, delete 메서드에 commentCount 계산 로직 추가