### PR TITLE
[버그] 좋아요 중복 알림 방지, 리뷰 댓글 오류 해결

### DIFF
--- a/src/main/java/com/part3/deokhugam/repository/NotificationRepository.java
+++ b/src/main/java/com/part3/deokhugam/repository/NotificationRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -58,4 +59,23 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
   boolean existsByUserIdAndReviewIdAndContentAndCreatedAtBetween(UUID userId, UUID reviewId, String content, Instant start,
       Instant end);
+
+  // 좋아요 알림 중복 검사용
+  boolean existsByUserIdAndReviewIdAndContent(UUID userId, UUID reviewId, String content);
+
+  // 좋아요 취소 시 해당 알림 삭제용
+  void deleteByUserIdAndReviewId(UUID userId, UUID reviewId);
+
+  @Modifying
+  @Query("""
+    DELETE FROM Notification n
+     WHERE n.user.id    = :userId
+       AND n.review.id  = :reviewId
+       AND n.content LIKE %:keyword%   
+  """)
+  void deleteLikeNotifications(
+      @Param("userId") UUID userId,
+      @Param("reviewId") UUID reviewId,
+      @Param("keyword")  String keyword
+  );
 }

--- a/src/main/java/com/part3/deokhugam/service/CommentService.java
+++ b/src/main/java/com/part3/deokhugam/service/CommentService.java
@@ -56,14 +56,24 @@ public class CommentService {
     reviewMetrics.increaseCommentCount();
     reviewMetricsRepository.save(reviewMetrics);
 
-    String notifContent = review.getContent().length() <= 50
-        ? review.getContent()
-        : review.getContent().substring(0, 50) + "...";
+    String commenterNickname = user.getNickname();
+
+    String commentContent = savedComment.getContent();
+
+    String commentSnippet = commentContent.length() <= 50
+        ? commentContent
+        : commentContent.substring(0, 50) + "...";
+
+    String notifContent = String.format(
+        "[%s]님이 나의 리뷰에 댓글을 남겼습니다.%n%s",
+        commenterNickname,
+        commentSnippet
+    );
 
     notificationService.createNotification(
         review.getUser().getId(),
         review,
-        notifContent + "님이 나의 리뷰에 댓글을 남겼습니다."
+        notifContent
     );
 
     return commentMapper.toDto(savedComment);

--- a/src/main/java/com/part3/deokhugam/service/NotificationService.java
+++ b/src/main/java/com/part3/deokhugam/service/NotificationService.java
@@ -39,6 +39,12 @@ public class NotificationService {
   ) {
     String content = chooseContent(review, customMessage);
 
+    boolean exists = repo.existsByUserIdAndReviewIdAndContent(
+        targetUserId, review.getId(), content);
+    if (exists) {
+      return null;
+    }
+
     Notification n = Notification.builder()
         .user(userRepository.getReferenceById(targetUserId))
         .review(review)
@@ -183,5 +189,12 @@ public class NotificationService {
     return repo.existsByUserIdAndReviewIdAndContentAndCreatedAtBetween(
         userId, reviewId, content, start, end
     );
+  }
+
+  // 좋아요 삭제시 기존 알림 삭제
+  @Transactional
+  public void deleteLikeNotification(UUID targetUserId, UUID reviewId) {
+    // 키워드로 알림구분
+    repo.deleteLikeNotifications(targetUserId, reviewId, "좋아요");
   }
 }


### PR DESCRIPTION
PR 타입(하나 이상의 PR 타입을 선택해주세요),
- [x]  기능 추가,,
- [ ]  기능 삭제,,
- [x]  버그 수정,,
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트,,
- [ ] 코드 리팩토링

반영 브랜치

fix/notification-like-duplicate-> develop

변경 사항

첫 번째 좋아요: 알림이 하나 생성
다시 좋아요(중복 클릭): 이미 exists → 알림 추가 안 함
좋아요 취소: 기존 “좋아요” 알림만 삭제
다시 좋아요 → 취소 반복: 알림이 쌓이지 않고, 취소 시 깔끔히 제거
